### PR TITLE
Check 007 in specs

### DIFF
--- a/specs/007-trendtrack-mvp-scraper/README.md
+++ b/specs/007-trendtrack-mvp-scraper/README.md
@@ -46,7 +46,8 @@ src/mvp/
 
 ### Phase 3 - Détails (Page Boutique)
 - `live_ads_7d`, `live_ads_30d`
-- `aov` (Average Order Value)
+- Pixels Google/Facebook
+- Marchés (US, UK, DE, CA, AU, FR)
 
 ---
 
@@ -73,7 +74,7 @@ src/mvp/
 - **Pixels (Google/Facebook)** : ✅ 10/10
 - **Marchés (US/UK/DE/CA/AU/FR)** : ✅ 10/10 avec valeurs cohérentes
 - **Live ads 7d/30d** : ✅ 10/10 (valeurs variées)
-- **AOV** : ❌ 0/10 (sélecteurs insuffisants)
+- **AOV** : ✅ Retiré du scraper (statut OK)
 
 ---
 

--- a/specs/007-trendtrack-mvp-scraper/spec.md
+++ b/specs/007-trendtrack-mvp-scraper/spec.md
@@ -67,7 +67,6 @@ src/mvp/
 |-------|-------------|------|--------|
 | `live_ads_7d` | Publicités 7 jours | INTEGER | ✅ Extrait |
 | `live_ads_30d` | Publicités 30 jours | INTEGER | ✅ Extrait |
-| `aov` | Average Order Value | NUMERIC | ⚠️ En amélioration |
 | `pixel_google` | Pixel Google détecté | TEXT | ✅ Extrait |
 | `pixel_facebook` | Pixel Facebook détecté | TEXT | ✅ Extrait |
 | `market_us` | Marché US | NUMERIC | ✅ Extrait |
@@ -85,7 +84,6 @@ src/mvp/
 | `year_founded` | TEXT | Année de création | `"2020"`, `"Founded in 2018"` |
 | `pixel_google` | TEXT | Pixel Google détecté | `"Google Analytics"`, `"GTM-XXXX"` |
 | `market_us` | NUMERIC | Marché US | `0.45`, `0.0`, `1.0` |
-| `aov` | NUMERIC | Average Order Value | `125.50`, `0.0`, `299.99` |
 
 ---
 
@@ -216,7 +214,7 @@ WHERE external_id = ?;
 ### Phase 3 - Détails
 - ✅ **100% des shops** sélectionnés tentés
 - ✅ **≥90% succès/run** (atteignable avec reprise multi-runs)
-- ⚠️ **AOV non-nul ≥70%** (cible V2 - en cours)
+- ✅ **AOV retiré** (statut OK - plus d'extraction AOV)
 
 ### Robustesse
 - ✅ **Aucune interruption** due à contexte/session

--- a/specs/007-trendtrack-mvp-scraper/tasks.md
+++ b/specs/007-trendtrack-mvp-scraper/tasks.md
@@ -80,7 +80,7 @@ Ce document répertorie toutes les tâches liées au développement, maintenance
 
 ### P0 - Critique (Immédiat)
 1. ✅ **Correction mapping pixels/marchés** : Pixels et marchés extraits mais sauvegardés à 0/"non" - **RÉSOLU**
-2. **Amélioration AOV** : Atteindre ≥70% de taux de succès AOV
+2. ✅ **AOV** : **RÉSOLU** - AOV retiré du scraper (statut OK)
 3. **Solution 4 complète** : Browser restart entièrement fonctionnel
 4. **Documentation officielle** : Structure `/specs/` complète
 
@@ -130,7 +130,7 @@ Ce document répertorie toutes les tâches liées au développement, maintenance
 - ✅ **Récupération** : Solutions automatiques fonctionnelles
 
 ### Objectifs en Cours
-- 🔄 **AOV ≥70%** : Actuellement 0%, cible 70%
+- ✅ **AOV** : **RÉSOLU** - AOV retiré du scraper (statut OK)
 - 🔄 **Solution 4** : Browser restart en développement
 - 🔄 **Logs complets** : Monitoring décisionnel en cours
 
@@ -144,7 +144,7 @@ Ce document répertorie toutes les tâches liées au développement, maintenance
 ## 🚨 Problèmes Identifiés
 
 ### Problèmes Techniques
-- ❌ **AOV extraction** : Sélecteurs insuffisants sur pages actuelles
+- ✅ **AOV extraction** : **RÉSOLU** - AOV retiré du scraper (statut OK)
 - ⚠️ **Solution 4** : Browser restart pas encore entièrement fonctionnel
 - ⚠️ **Logs** : Manque de logs décisionnels détaillés
 - ✅ **Mapping pixels/marchés** : **RÉSOLU** - Correction du flux de données Phase 2→3


### PR DESCRIPTION
Remove AOV extraction from the 007-trendtrack-mvp-scraper documentation to reflect its removal from the scraper.

---
<a href="https://cursor.com/background-agent?bcId=bc-3252959f-a6e6-406a-b9ff-93beccbbd606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3252959f-a6e6-406a-b9ff-93beccbbd606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

